### PR TITLE
Issue #SC-1087 Fix readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,85 @@
+dump.json
+.DS_Store
+
+.project
+.classpath
+.vscode
+
+/.idea
+*.iml
+.idea_modules
+.idea/vcs.xml
+
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+logs
+*.log
+
+target
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Properties
+config-*.properties
+application.properties
+application.yml
+application.yml.old
+
+# Json-LD
+schema-configuration.jsonld
+schema-configuration-school-test.jsonld
+frame.json
+
+# Shex file
+validations.shex
+validations_create.shex
+validations_update.shex

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # sunbird-user-registry
-Opensaber implementation for Sunbird
+This is a copy of OpenSABER maintained [here](https://github.com/project-sunbird/open-saber) with additional schemas 
+pertaining to Sunbird user-org service. This is maintained by Sunbird user-org team.
 
-Configration changes regarding opensaber for Sunbird:
+## Building this repo
 
-Crated sunbird-user-registry service on the base of open-saber(https://github.com/project-sunbird/open-saber) with branch release-2.0.3
+### 1. Run dependency resolver 
+Copies/Overwrites the user related json schema files and application configuration from the sb_registry folder. Additionally, 
+takes a backup of the existing application.yml.  
 
-Run sb-registry-configure-dependencies.sh file which copies User related json schemas and application.yml configuration and replaces the exisiting configuration files.
+> ./sb-registry-configure-dependencies.sh 
 
-Go to java folder path and run "mvn clean install" in the terminal, it gives registry executable jar.
-
-Run the registry jar with "java -jar registry-2.0.3.jar".
-
-Start using the sunbird-user-registry with user related schemas, organisation related schemas will be added soon.
-
+### 2. Go to java folder and build
+> mvn clean install
 
 
+## Ready to go
+Now you can run, the application uses 8080 port  
+> "java -jar registry-x.y.z.jar"

--- a/java/registry/src/main/resources/application.yml.sample
+++ b/java/registry/src/main/resources/application.yml.sample
@@ -48,7 +48,7 @@ search:
 # This property is to be used for read request
 read:
   # The read mechanism to use, values could be either NativeReadService or ElasticReadService
-  providerName: io.opensaber.registry.service.ElasticReadService
+  providerName: io.opensaber.registry.service.NativeReadService
 
 database:
   # This property is internal and not to be confused with the schema definition.
@@ -75,39 +75,30 @@ database:
   shardAdvisorClassName: io.opensaber.registry.sink.shard.DefaultShardAdvisor
 
   connectionInfo:
-    -
-      # shardId, shardlabel must be a unique identifier to each connection.
-      shardId: shard1
+      -
+        # shardId, shardlabel must be a unique identifier to each connection.
+        shardId: ${database_connectionInfo_shardId:shard1}
 
-      # shardLabel is used as prefix for a uuid. Could be any alpha numeric string
-      # Example of a record identifier: 1-60f76147-0acd-4dff-b75a-2d811787d04d
-      # Note '1' is the label used for record identifier
-      # shardLabel is not stored in the database
-      shardLabel: 1
+        # shardLabel is used as prefix for a uuid. Could be any alpha numeric string
+        # Example of a record identifier: 1-60f76147-0acd-4dff-b75a-2d811787d04d
+        # Note '1' is the label used for record identifier
+        # shardLabel is not stored in the database
+        shardLabel: ${database_connectionInfo_shardLabel:1}
 
-      # The format of the URI can be learnt from the following links -
-      #     * 1. Graph database (Neo4J)
-      #     ** https://github.com/SteelBridgeLabs/neo4j-gremlin-bolt
-      #     ** Example : bolt://localhost:7687
-      #     * 2. Relational databases (Postgresql, HSQLDB, H2, MariaDB, MySQL, MSSQLServer)
-      #     ** http://sqlg.org/docs/2.0.0-SNAPSHOT/
-      #     ** Example - Postgres - jdbc:postgresql://localhost:5432/yourdb
-      #     * 3. NoSQL  databases (Cassandra-Janusgraph)
-      #     ** Example - cassandra - jdbc:cassandra://localhost:9160/yourdb
-      #     * 4 Cassandra
-      #     ** Example - cassandra - 127.0.0.1:9042
-      uri: ${connectionInfo_uri:jdbc:postgresql://localhost:5432/perfbench5}
-
-      username: ${connectionInfo_username:postgres}
-      password: ${connectionInfo_password:postgres}
-
-      # Any other shard information follows...
-    #-
-      #shardId: shard2
-      #shardLabel: 2
-      #uri: ${connectionInfo_uri:jdbc:postgresql://localhost:5432/yourdb}
-      #username: ${connectionInfo_username:postgres}
-      #password: ${connectionInfo_password:postgres}
+        # The format of the URI can be learnt from the following links -
+        #     * 1. Graph database (Neo4J)
+        #     ** https://github.com/SteelBridgeLabs/neo4j-gremlin-bolt
+        #     ** Example : bolt://localhost:7687
+        #     * 2. Relational databases (Postgresql, HSQLDB, H2, MariaDB, MySQL, MSSQLServer)
+        #     ** http://sqlg.org/docs/2.0.0-SNAPSHOT/
+        #     ** Example - Postgres - jdbc:postgresql://localhost:5432/yourdb
+        #     * 3. NoSQL  databases (Cassandra-Janusgraph)
+        #     ** Example - cassandra - jdbc:cassandra://localhost:9160/yourdb
+        #     * 4 Cassandra
+        #     ** Example - cassandra - 127.0.0.1:9042
+        uri: ${database_connectionInfo_uri:jdbc:postgresql://localhost:5432/opensaber}
+        username: ${database_connectionInfo_username:postgres}
+        password: ${database_connectionInfo_password:postgres}
 
 ##################################################################################
 # Uncomment the following section to use Cassandra as backend store              #
@@ -129,7 +120,7 @@ frame:
   file: ${frame_file:frame.json}
 
 encryption:
-  enabled: ${encryption_enabled:true}
+  enabled: ${encryption_enabled:false}
   base: ${encryption_base:http://localhost:8013}
   uri: ${encryption_uri:http://localhost:8013/encrypt}
   batch:
@@ -141,7 +132,7 @@ decryption:
     uri: ${decryption_batch_uri:http://localhost:8013/decrypt/obj}
 
 signature:
-  enabled: ${signature_enabled:true}
+  enabled: ${signature_enabled:false}
   healthCheckURL: ${sign_health_check_url:http://localhost:8013/}
   signURL: ${sign_url:http://localhost:8013/sign}
   verifyURL: ${verify_url:http://localhost:8013/verify}
@@ -157,7 +148,7 @@ signature:
     #file: ${audit_frame_file:audit_frame.json}
 
 authentication:
-  enabled: ${authentication_enabled:true}
+  enabled: ${authentication_enabled:false}
 
 keycloak:
   sso:
@@ -214,7 +205,7 @@ auditTaskExecutor:
 elastic:
   search:
     # elastic-search can be enable and disable through this flag
-    enabled: ${elastic_search_enabled:true}
+    enabled: ${elastic_search_enabled:false}
     # elastic-search connection info
     connection_url: ${elastic_search_connection_url:localhost:9200}
 

--- a/java/registry/src/main/resources/public/_schemas/Address.json
+++ b/java/registry/src/main/resources/public/_schemas/Address.json
@@ -72,6 +72,6 @@
     "signedFields": [],
     "indexFields": ["userId"],
     "uniqueIndexFields": [],
-    "systemFields": ["createdAt", "updatedAt", "createdBy", "updatedBy"]
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/Education.json
+++ b/java/registry/src/main/resources/public/_schemas/Education.json
@@ -37,7 +37,7 @@
           "title": "Grade"
         },
         "isDeleted": {
-          "type": "string",
+          "type": "boolean",
           "title": "Is Deleted"
         },
         "name": {

--- a/java/registry/src/main/resources/public/_schemas/Education.json
+++ b/java/registry/src/main/resources/public/_schemas/Education.json
@@ -71,6 +71,6 @@
     "signedFields": [],
     "indexFields": ["userId"],
     "uniqueIndexFields": [],
-    "systemFields": ["createdAt", "updatedAt", "createdBy", "updatedBy"]
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/ExternalId.json
+++ b/java/registry/src/main/resources/public/_schemas/ExternalId.json
@@ -46,6 +46,6 @@
     "signedFields": [],
     "indexFields": ["userId"],
     "uniqueIndexFields": [],
-    "systemFields": ["createdOn", "createdBy"]
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/JobProfile.json
+++ b/java/registry/src/main/resources/public/_schemas/JobProfile.json
@@ -87,6 +87,6 @@
     "signedFields": [],
     "indexFields": ["userId"],
     "uniqueIndexFields": [],
-    "systemFields": ["createdAt", "updatedAt", "createdBy", "updatedBy"]
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/User.json
+++ b/java/registry/src/main/resources/public/_schemas/User.json
@@ -138,8 +138,8 @@
 
     "privateFields": ["phone", "email", "userName", "status", "loginId"],
     "signedFields": [],
-    "indexFields": ["email","status","userName","phone","loginId"],
-    "uniqueIndexFields": ["email","phone","loginId"],
+    "indexFields": ["email","status","userName","phone"],
+    "uniqueIndexFields": ["email","phone"],
     "systemFields": ["createdAt", "updatedAt", "createdBy", "updatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/User.json
+++ b/java/registry/src/main/resources/public/_schemas/User.json
@@ -136,10 +136,10 @@
       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name",
       "systemFields: Optional; list of fields names used for system standard information like created, updated timestamps and userid"],
 
-    "privateFields": ["phone", "email", "userName", "status", "loginId"],
+    "privateFields": ["phone", "email", "userName", "status"],
     "signedFields": [],
-    "indexFields": ["email","status","userName","phone"],
-    "uniqueIndexFields": ["email","phone"],
-    "systemFields": ["createdAt", "updatedAt", "createdBy", "updatedBy"]
+    "indexFields": [],
+    "uniqueIndexFields": ["email","phone","userName"],
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/UserFieldStatus.json
+++ b/java/registry/src/main/resources/public/_schemas/UserFieldStatus.json
@@ -66,8 +66,8 @@
 
     "privateFields": [],
     "signedFields": [],
-    "indexFields": ["loginId"],
-    "uniqueIndexFields": ["loginId"],
-    "systemFields": ["createdOn", "updatedAt", "createdBy", "updatedBy"]
+    "indexFields": ["userId"],
+    "uniqueIndexFields": [],
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/UserFieldStatus.json
+++ b/java/registry/src/main/resources/public/_schemas/UserFieldStatus.json
@@ -66,6 +66,8 @@
 
     "privateFields": [],
     "signedFields": [],
+    "indexFields": ["loginId"],
+    "uniqueIndexFields": ["loginId"],
     "systemFields": ["createdOn", "updatedAt", "createdBy", "updatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/UserOrg.json
+++ b/java/registry/src/main/resources/public/_schemas/UserOrg.json
@@ -68,6 +68,6 @@
     "signedFields": [],
     "indexFields": ["userId"],
     "uniqueIndexFields": [],
-    "systemFields": ["updatedAt", "updatedBy"]
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/java/registry/src/main/resources/public/_schemas/UserSkills.json
+++ b/java/registry/src/main/resources/public/_schemas/UserSkills.json
@@ -59,6 +59,6 @@
     "signedFields": [],
     "indexFields": ["userId"],
     "uniqueIndexFields": [],
-    "systemFields": ["createdOn", "updatedAt", "createdBy", "updatedBy"]
+    "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/sb-registry-configure-dependencies.sh
+++ b/sb-registry-configure-dependencies.sh
@@ -6,6 +6,7 @@ cp java/registry/src/main/resources/audit_frame.json.sample java/registry/src/ma
 rm java/registry/src/main/resources/public/_schemas/*
 cp sb_registry/schemas/* java/registry/src/main/resources/public/_schemas/
 cp sb_registry/application.yml.sample java/registry/src/main/resources/application.yml.sample
+cp java/registry/src/main/resources/application.yml java/registry/src/main/resources/application.yml.old
 cp java/registry/src/main/resources/application.yml.sample java/registry/src/main/resources/application.yml
 
 echo "Configuration of dependencies completed"

--- a/sb_registry/schemas/User.json
+++ b/sb_registry/schemas/User.json
@@ -136,10 +136,10 @@
       "uniqueIndexFields: Optional; list of field names used for creating unique index. Field names must be different from index field name",
       "systemFields: Optional; list of fields names used for system standard information like created, updated timestamps and userid"],
 
-    "privateFields": ["phone", "email", "userName", "status", "loginId"],
+    "privateFields": ["phone", "email", "userName", "status"],
     "signedFields": [],
-    "indexFields": ["email","status","userName","phone"],
-    "uniqueIndexFields": ["email","phone"],
+    "indexFields": [],
+    "uniqueIndexFields": ["email","phone","userName"],
     "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }

--- a/sb_registry/schemas/UserFieldStatus.json
+++ b/sb_registry/schemas/UserFieldStatus.json
@@ -66,8 +66,8 @@
 
     "privateFields": [],
     "signedFields": [],
-    "indexFields": ["loginId"],
-    "uniqueIndexFields": ["loginId"],
+    "indexFields": ["userId"],
+    "uniqueIndexFields": [],
     "systemFields": ["osCreatedAt", "osUpdatedAt", "osCreatedBy", "osUpdatedBy"]
   }
 }


### PR DESCRIPTION
Appears we have the user/org schemas in two places - 1) sb_registry folder (source) and 2) in java/main/resources/schemas. Both of them are checked in. So, checking in 2) files as well to maintain. Perhaps we can shed this away and retain only the sb_registry.

Using the application.yml.sample, one creates the application.yml (not checked-in), so that it allows developers to change their config locally (passwords, URLs etc).

Fixed README to clearer messaging.